### PR TITLE
include <unistd.h>

### DIFF
--- a/bpgmux.c
+++ b/bpgmux.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <getopt.h>
 #include <math.h>
+#include <unistd.h>
 
 #include "bpgfmt.h"
 #include "libbpg.h"


### PR DESCRIPTION
Fixes `implicit declaration of function ‘unlink’ [-Wimplicit-function-declaration]` warning on gcc.
