### PR TITLE
add missing field initializers

### DIFF
--- a/bpgenc.c
+++ b/bpgenc.c
@@ -2609,19 +2609,19 @@ static void help(int is_full)
 }
 
 static struct option long_opts[] = {
-    { "hash", no_argument },
-    { "keepmetadata", no_argument },
-    { "alphaq", required_argument },
-    { "lossless", no_argument },
-    { "limitedrange", no_argument },
-    { "premul", required_argument },
-    { "loop", required_argument },
-    { "fps", required_argument },
-    { "delayfile", required_argument },
-    { "aq", required_argument },
-    { "chroma-offset", required_argument },
-    { "deblock", required_argument },
-    { "psy", required_argument },
+    { "hash", no_argument, 0, 0 },
+    { "keepmetadata", no_argument, 0, 0 },
+    { "alphaq", required_argument, 0, 0 },
+    { "lossless", no_argument, 0, 0 },
+    { "limitedrange", no_argument, 0, 0 },
+    { "premul", required_argument, 0, 0 },
+    { "loop", required_argument, 0, 0 },
+    { "fps", required_argument, 0, 0 },
+    { "delayfile", required_argument, 0, 0 },
+    { "aq", required_argument, 0, 0 },
+    { "chroma-offset", required_argument, 0, 0 },
+    { "deblock", required_argument, 0, 0 },
+    { "psy", required_argument, 0, 0 },
     { NULL },
 };
 

--- a/bpgmux.c
+++ b/bpgmux.c
@@ -1283,12 +1283,12 @@ static void mux_help(int is_full)
 }
 
 static struct option mux_adv_opts[] = {
-    { "limitedrange", required_argument },
-    { "premul", no_argument },
-    { "loop", required_argument },
-    { "fps", required_argument },
-    { "frames", required_argument },
-    { "delayfile", required_argument },
+    { "limitedrange", required_argument, 0, 0 },
+    { "premul", no_argument, 0, 0 },
+    { "loop", required_argument, 0, 0 },
+    { "fps", required_argument, 0, 0 },
+    { "frames", required_argument, 0, 0 },
+    { "delayfile", required_argument, 0, 0 },
     { NULL },
 };
 


### PR DESCRIPTION
stops gcc's -Wmissing-field-initializers warning
