### PR TITLE
avoid implicit declaration of function 'strrchr'

### DIFF
--- a/bpgdec.c
+++ b/bpgdec.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <strings.h>
 #include <math.h>
 #include <getopt.h>


### PR DESCRIPTION
Prevents this warning when compiling on Linux:

```
bpgdec.c: In function 'main':
bpgdec.c:340:5: warning: implicit declaration of function 'strrchr' [-Wimplicit-function-declaration]
     p = strrchr(outfilename, '.');
     ^
bpgdec.c:340:9: warning: incompatible implicit declaration of built-in function 'strrchr' [enabled by default]
     p = strrchr(outfilename, '.');
         ^
```
